### PR TITLE
fix issue with `System.InvalidOperationException: Collection was modi…

### DIFF
--- a/MyServiceBus.TcpClient/PayLoadCollector.cs
+++ b/MyServiceBus.TcpClient/PayLoadCollector.cs
@@ -166,6 +166,8 @@ namespace MyServiceBus.TcpClient
 
         public void SetPublished(long requestId)
         {
+            var taskToComplete = new List<TaskCompletionSource<int>>();
+
             lock (_readyToGo)
             {
                 foreach (var topicData in _readyToGo.Where(topicData => topicData.Value.Count > 0))
@@ -176,10 +178,15 @@ namespace MyServiceBus.TcpClient
                         continue;
 
                     topicData.Value.RemoveAt(0);
-                    packageToCommit.CommitTask.SetResult(0);
+
+                    taskToComplete.Add(packageToCommit.CommitTask);
                 }
             }
-            
+
+            foreach (var task in taskToComplete)
+            {
+                task.SetResult(0);
+            }
         }
 
         private long _lastDisconnectId = -1;


### PR DESCRIPTION
if we send messages in 2 different topics then in servicebus client we receive error

```
[11:47:49 INF] MyServiceBusTcpClient[Socket 0|[::ffff:192.168.10.80]:6421|True][Exception] Collection was modified after the enumerator was instantiated.
System.InvalidOperationException: Collection was modified after the enumerator was instantiated.
   at System.Collections.Generic.SortedSet`1.Enumerator.MoveNext()
   at System.Linq.Enumerable.WhereEnumerableIterator`1.MoveNext()
   at MyServiceBus.TcpClient.PayLoadCollector.SetPublished(Int64 requestId)
   at MyServiceBus.TcpClient.MyServiceBusTcpContext.HandlePublishResponse(PublishResponseContract pr)
   at MyServiceBus.TcpClient.MyServiceBusTcpContext.HandleIncomingDataAsync(IServiceBusTcpContract data)
   at MyTcpSockets.TcpContext`1.ReadLoopAsync(Int32 bufferSize)
```
